### PR TITLE
Allow additional args for maven.

### DIFF
--- a/circle/build-java-service.sh
+++ b/circle/build-java-service.sh
@@ -9,7 +9,11 @@
 
 set -e
 
-mvn deploy
+if [ -z "${MVN_ARGS}" ]; then
+  mvn deploy 
+else
+  mvn deploy ${MVN_ARGS}
+fi
 
 set +e
 


### PR DESCRIPTION
By setting MVN_ARGS the build user can customize the arguments passed during a mvn deploy.