### PR TITLE
Add support for prod-cdeaccess cluster for deploy

### DIFF
--- a/circle/do-ecs-deployment.sh
+++ b/circle/do-ecs-deployment.sh
@@ -26,6 +26,9 @@ while IFS=: read REPO ECS_SERVICE; do
     elif [ "${ECS_PROD_CLUSTER}" = "prod-cde" ] ; then
       ECS_SERVICE_PREFIX='prod-cde-'
       ECSMAN_ARGS="${ECS_PROD_CLUSTER} ${ECS_SERVICE_PREFIX}${REPO}${PROD_ECS_SUFFIX} :${SPECIFIC_BRANCH}"
+    elif [ "${ECS_PROD_CLUSTER}" = "prod-cdeaccess" ] ; then
+      ECS_SERVICE_PREFIX='prod-cdeaccess-'
+      ECSMAN_ARGS="${ECS_PROD_CLUSTER} ${ECS_SERVICE_PREFIX}${REPO}${PROD_ECS_SUFFIX} :${SPECIFIC_BRANCH}"
     else
       ECSMAN_ARGS="${ECS_PROD_CLUSTER} ${ECS_SERVICE}${PROD_ECS_SUFFIX} :${SPECIFIC_BRANCH}"
     fi

--- a/circle2/do-ecs-deployment.sh
+++ b/circle2/do-ecs-deployment.sh
@@ -27,6 +27,9 @@ while IFS=: read REPO ECS_SERVICE; do
     elif [ "${ECS_PROD_CLUSTER}" = "prod-cde" ] ; then
       ECS_SERVICE_PREFIX='prod-cde-'
       ECSMAN_ARGS="${ECS_PROD_CLUSTER} ${ECS_SERVICE_PREFIX}${REPO}${PROD_ECS_SUFFIX} :${SPECIFIC_BRANCH}"
+    elif [ "${ECS_PROD_CLUSTER}" = "prod-cdeaccess" ] ; then
+      ECS_SERVICE_PREFIX='prod-cdeaccess-'
+      ECSMAN_ARGS="${ECS_PROD_CLUSTER} ${ECS_SERVICE_PREFIX}${REPO}${PROD_ECS_SUFFIX} :${SPECIFIC_BRANCH}"
     else
       ECSMAN_ARGS="${ECS_PROD_CLUSTER} ${ECS_SERVICE}${PROD_ECS_SUFFIX} :${SPECIFIC_BRANCH}"
     fi


### PR DESCRIPTION
Service name generation is based on the associated cluster. Updated the
deploy script to be able to generate correct names for prod-cdeaccess.